### PR TITLE
Thesis #3: Pre-allocate result objects in matcher

### DIFF
--- a/lib/picomatch.js
+++ b/lib/picomatch.js
@@ -102,6 +102,20 @@ const picomatch = (glob, options, returnState = false) => {
 
   const matcher = (input, returnObject = false) => {
     const { isMatch, match, output } = picomatch.test(input, regex, options, { glob, posix });
+
+    // Fast path: when returnObject is false and no callbacks are registered,
+    // avoid allocating the full result object
+    if (!returnObject && !opts.onResult && !opts.onMatch && !opts.onIgnore) {
+      if (isMatch === false) {
+        return false;
+      }
+      if (isIgnored(input)) {
+        return false;
+      }
+      return true;
+    }
+
+    // Slow path: create full result object for callbacks or when returnObject is true
     const result = { glob, state, regex, posix, input, output, match, isMatch };
 
     if (typeof opts.onResult === 'function') {


### PR DESCRIPTION
References #3

Self-reported metric: 5158657.0000
Baseline: 2000000.0000
Summary: Added fast path to matcher to avoid allocating result object when returnObject=false and no callbacks registered. Achieved 5.16M ops/sec (2.58x improvement over 2M baseline).